### PR TITLE
Replace unknown bone struct with 4x4 matrix

### DIFF
--- a/src/Files/Win32Model.md
+++ b/src/Files/Win32Model.md
@@ -33,7 +33,7 @@ import std.string;
 using CString = std::string::NullString;
 
 struct Bone {
-    type::Hex<u32> ukn[16];
+    float transform[16]; // 4x4 matrix
 };
 
 struct ResourceKey {


### PR DESCRIPTION
This PR replaces the unknown Bone structure with a 4x4 transform matrix. Based on results from ImHex like the one shown in the screenshot. This matches what we see in rigged Win32 models. The matrix structure fits well with typical transforms (translation, etc.), and the values line up as expected.

<img width="592" height="344" alt="image" src="https://github.com/user-attachments/assets/237e4156-e1a9-4296-b8b1-fe916e533c86" />
