### PR TITLE
Remove 4 byte padding for MTST data

### DIFF
--- a/src/Files/Material/MySims.md
+++ b/src/Files/Material/MySims.md
@@ -83,7 +83,6 @@ struct MTST {
     u32 index;
     u32 count;
     u32 indicies[count];
-    padding[4];
 };
 
 struct MaterialSet {


### PR DESCRIPTION
This pull request removed the 4 bytes of padding at the end of an MTST block. The padding was causing both ImHex and my own code to attempt to read past the bounds of the buffer.

I've applied this change to my library in [this commit](https://github.com/bottledlactose/essencio/commit/ed4784b1ac3448b6c2c19bb7f1c8e2b8d605ecfa) which has fixed material set loading for me.

Comparison with and without the padding in ImHex:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/a7b1e278-2921-4b2f-82b9-bb8f7127ef20" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/401835a6-bbf9-422d-90c9-fd9f836e9d66" />

